### PR TITLE
Revamp sleep journal with dreamy UI and 24h time validation

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import '../styles/globals.css';
-export const metadata = { title: 'Sleep Journal', description: 'Soothing pastel sleep journal with Supabase sync' };
+export const metadata = { title: 'Sleep Journal', description: 'Dreamy futuristic sleep journal with Supabase sync' };
 
 const ThemeScript = () => (
   <script

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -43,7 +43,7 @@ export default function Page(){
   }
   useEffect(()=>{ refreshAvg(); }, [session]);
 
-  // pastel palette for the dynamic glow
+  // base palette for the dynamic glow
   const palette = useMemo(()=>({ a:'#cfe8ff', b:'#ffe1e8', c:'#e3f7e8' }),[]);
   const toggleTheme = ()=>{
     const next = theme === 'dark' ? 'light' : 'dark';
@@ -62,7 +62,7 @@ export default function Page(){
           <div className="brand">
             <span className="dot" />
             <span>Sleep Journal</span>
-            <span className="muted">• pastel & calming</span>
+            <span className="muted">• drift into dreams</span>
           </div>
           <div className="rowflex">
             <button className="ghost" onClick={toggleTheme}>Toggle Theme</button>
@@ -94,7 +94,6 @@ export default function Page(){
           </section>
         )}
 
-        <p className="footer">Vercel-ready • Supabase sync • Dynamic glow ✨</p>
       </div>
     </main>
   );

--- a/components/EntriesList.tsx
+++ b/components/EntriesList.tsx
@@ -12,20 +12,13 @@ type Row = {
   notes: string|null;
 };
 
-type ActionStyle = 'icons' | 'text';
+const timeRegex = /^([01]?\d|2[0-3]):[0-5]\d$/;
+const isValidTime = (v:string)=> timeRegex.test(v);
 
 export default function EntriesList({ refreshKey = 0 }: { refreshKey?: number }) {
   const [rows, setRows] = useState<Row[]|null>(null);
   const [editing, setEditing] = useState<Row | null>(null);
   const [loadingId, setLoadingId] = useState<string | null>(null);
-  const [actionStyle, setActionStyle] = useState<ActionStyle>(() => {
-    if (typeof localStorage === 'undefined') return 'icons';
-    return (localStorage.getItem('entries_action_style') as ActionStyle) || 'icons';
-  });
-
-  useEffect(() => {
-    try { localStorage.setItem('entries_action_style', actionStyle); } catch {}
-  }, [actionStyle]);
 
   async function load(){
     const { data: { user } } = await supabase.auth.getUser();
@@ -76,60 +69,24 @@ export default function EntriesList({ refreshKey = 0 }: { refreshKey?: number })
 
   return (
     <>
-      {/* Small control to switch Icons/Text */}
-      <div className="actions-style">
-        <span className="muted" style={{fontSize:13}}>Actions:</span>
-        <div className="segmented">
-          <button
-            className={`seg ${actionStyle==='icons'?'on':''}`}
-            onClick={()=>setActionStyle('icons')}
-            type="button"
-          >Icons</button>
-          <button
-            className={`seg ${actionStyle==='text'?'on':''}`}
-            onClick={()=>setActionStyle('text')}
-            type="button"
-          >Text</button>
-        </div>
-      </div>
-
       <div className="sleek-list">
         {rows.map(r=> (
           <article key={r.id} className="entry sleek">
             <div className="entry-head">
               <div className="entry-date">{fmtDate(r.entry_date)}</div>
               <div className="entry-actions">
-                {actionStyle === 'icons' ? (
-                  <>
-                    <button className="iconbtn" onClick={()=>openEdit(r)} aria-label="Edit">
-                      <span aria-hidden>✏️</span><span className="sr-only">Edit</span>
-                    </button>
-                    <button
-                      className="iconbtn danger"
-                      onClick={()=>onDelete(r.id)}
-                      disabled={loadingId===r.id}
-                      aria-label="Delete"
-                    >
-                      <span aria-hidden>{loadingId===r.id ? '…' : '🗑️'}</span>
-                      <span className="sr-only">Delete</span>
-                    </button>
-                  </>
-                ) : (
-                  <>
-                    <button className="textbtn" onClick={()=>openEdit(r)}>Edit</button>
-                    <button
-                      className="textbtn danger"
-                      onClick={()=>onDelete(r.id)}
-                      disabled={loadingId===r.id}
-                    >{loadingId===r.id ? 'Deleting…' : 'Delete'}</button>
-                  </>
-                )}
+                <button className="textbtn" onClick={()=>openEdit(r)}>Edit</button>
+                <button
+                  className="textbtn danger"
+                  onClick={()=>onDelete(r.id)}
+                  disabled={loadingId===r.id}
+                >{loadingId===r.id ? 'Deleting…' : 'Delete'}</button>
               </div>
             </div>
 
             <div className="entry-meta">
               <span className="muted">{r.bedtime||'—'} → {r.waketime||'—'}</span>
-              <span className="chip">{r.duration_minutes ? fmtHM(r.duration_minutes) : '—'}</span>
+              <span className="chip">Duration {r.duration_minutes ? fmtHM(r.duration_minutes) : '—'}</span>
               <span className="stars" title={`${r.quality ?? 0} / 5`}>
                 {renderStars(r.quality ?? 0)}
               </span>
@@ -159,6 +116,8 @@ function EditModal({ row, onClose, onSave }:{
   const [date, setDate] = useState(row.entry_date);
   const [bed, setBed] = useState(row.bedtime || '');
   const [wake, setWake] = useState(row.waketime || '');
+  const [bedError, setBedError] = useState('');
+  const [wakeError, setWakeError] = useState('');
   const [quality, setQuality] = useState(row.quality ?? 3);
   const [notes, setNotes] = useState(row.notes || '');
 
@@ -180,8 +139,8 @@ function EditModal({ row, onClose, onSave }:{
 
         <div className="rowflex wrap" style={{gap:12}}>
           <div className="field"><label>Date</label><input type="date" value={date} onChange={e=>setDate(e.target.value)} required/></div>
-          <div className="field"><label>Bedtime</label><input type="time" value={bed} onChange={e=>setBed(e.target.value)} /></div>
-          <div className="field"><label>Wake time</label><input type="time" value={wake} onChange={e=>setWake(e.target.value)} /></div>
+          <div className="field"><label>Bedtime</label><input type="text" placeholder="HH:MM" value={bed} onChange={e=>{ const v=e.target.value; setBed(v); setBedError(isValidTime(v)?'':'Use HH:MM'); }} inputMode="numeric" />{bedError && <p className="error">{bedError}</p>}</div>
+          <div className="field"><label>Wake time</label><input type="text" placeholder="HH:MM" value={wake} onChange={e=>{ const v=e.target.value; setWake(v); setWakeError(isValidTime(v)?'':'Use HH:MM'); }} inputMode="numeric" />{wakeError && <p className="error">{wakeError}</p>}</div>
         </div>
 
         <label style={{marginTop:10}}>Sleep quality: <b>{quality}</b></label>
@@ -191,10 +150,10 @@ function EditModal({ row, onClose, onSave }:{
         <textarea rows={4} placeholder="Caffeine? Exercise? Woke at night?" value={notes} onChange={e=>setNotes(e.target.value)} />
 
         <div className="rowflex between" style={{marginTop:14}}>
-          <span className="chip">⏱ {fmtHM(duration)}</span>
+          <span className="chip">Duration {duration>0 ? fmtHM(duration) : '—'}</span>
           <div className="rowflex" style={{gap:8}}>
             <button className="ghost" onClick={onClose}>Cancel</button>
-            <button onClick={()=> onSave({ entry_date: date, bedtime: bed, waketime: wake, quality, notes })}>Save</button>
+            <button onClick={()=>{ const bOk=isValidTime(bed); const wOk=isValidTime(wake); setBedError(bOk?'':'Use HH:MM'); setWakeError(wOk?'':'Use HH:MM'); if(bOk && wOk) onSave({ entry_date: date, bedtime: bed, waketime: wake, quality, notes }); }}>Save</button>
           </div>
         </div>
       </div>
@@ -210,6 +169,7 @@ function fmtHM(mins:number){ const h = Math.floor(mins/60), m = mins%60; return 
 function escapeHtml(s:string){ return s.replace(/[&<>"']/g, (c)=>({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;' } as any)[c]); }
 function estimateDurationMinutes(dateStr?: string, bedStr?: string, wakeStr?: string){
   if(!dateStr || !bedStr || !wakeStr) return 0;
+  if(!isValidTime(bedStr) || !isValidTime(wakeStr)) return 0;
   const [bh,bm] = bedStr.split(':').map(Number);
   const [wh,wm] = wakeStr.split(':').map(Number);
   const d = new Date(dateStr + 'T00:00:00');

--- a/components/GlowBackground.tsx
+++ b/components/GlowBackground.tsx
@@ -34,6 +34,8 @@ export default function GlowBackground({ theme }: Props){
       ref={ref}
       className={`glow glow-full ${theme === 'dark' ? 'glow-dark' : 'glow-light'}`}
       aria-hidden
-    />
+    >
+      {theme === 'dark' && <div className="glow-grid" />}
+    </div>
   );
 }

--- a/components/SleepForm.tsx
+++ b/components/SleepForm.tsx
@@ -11,17 +11,23 @@ export default function SleepForm({ onSaved }:{ onSaved?: ()=>void }){
   const [date, setDate] = useState(`${yyyy}-${mm}-${dd}`);
   const [bed, setBed] = useState('');
   const [wake, setWake] = useState('');
+  const [bedError, setBedError] = useState('');
+  const [wakeError, setWakeError] = useState('');
   const [quality, setQuality] = useState(3);
   const [notes, setNotes] = useState('');
   const [duration, setDuration] = useState('0h 00m');
 
   useEffect(()=>{
     const mins = estimateDurationMinutes(date, bed, wake);
-    setDuration(fmtHM(mins));
+    setDuration(mins>0 ? fmtHM(mins) : '—');
   },[date, bed, wake]);
+
+  const timeRegex = /^([01]?\d|2[0-3]):[0-5]\d$/;
+  const isValidTime = (v:string)=> timeRegex.test(v);
 
   function estimateDurationMinutes(dateStr?: string, bedStr?: string, wakeStr?: string){
     if(!dateStr || !bedStr || !wakeStr) return 0;
+    if(!isValidTime(bedStr) || !isValidTime(wakeStr)) return 0;
     const [by, bm] = bedStr.split(':').map(Number);
     const [wy, wm] = wakeStr.split(':').map(Number);
     const d = new Date(dateStr + 'T00:00:00');
@@ -34,10 +40,12 @@ export default function SleepForm({ onSaved }:{ onSaved?: ()=>void }){
 
   async function onSubmit(e: React.FormEvent){
     e.preventDefault();
+    const bedOk = isValidTime(bed); setBedError(bedOk ? '' : 'Use HH:MM');
+    const wakeOk = isValidTime(wake); setWakeError(wakeOk ? '' : 'Use HH:MM');
+    if(!bedOk || !wakeOk) return;
     const user = (await supabase.auth.getUser()).data.user;
     if(!user) return alert('Please sign in.');
     const payload = { user_id: user.id, entry_date: date, bedtime: bed, waketime: wake, duration_minutes: estimateDurationMinutes(date,bed,wake), quality, notes };
-    console.log('saving entry', payload);
     const { error } = await supabase.from('sleep_entries').insert(payload);
     if(error) return alert(error.message);
     setBed(''); setWake(''); setQuality(3); setNotes('');
@@ -48,15 +56,15 @@ export default function SleepForm({ onSaved }:{ onSaved?: ()=>void }){
     <form onSubmit={onSubmit}>
       <div className="rowflex wrap">
         <div className="field"><label>Date</label><input type="date" value={date} onChange={e=>setDate(e.target.value)} required/></div>
-        <div className="field"><label>Bedtime</label><input type="time" value={bed} onChange={e=>setBed(e.target.value)} required/></div>
-        <div className="field"><label>Wake time</label><input type="time" value={wake} onChange={e=>setWake(e.target.value)} required/></div>
+        <div className="field"><label>Bedtime</label><input type="text" placeholder="HH:MM" value={bed} onChange={e=>{ const v=e.target.value; setBed(v); setBedError(isValidTime(v)?'':'Use HH:MM'); }} inputMode="numeric" required/>{bedError && <p className="error">{bedError}</p>}</div>
+        <div className="field"><label>Wake time</label><input type="text" placeholder="HH:MM" value={wake} onChange={e=>{ const v=e.target.value; setWake(v); setWakeError(isValidTime(v)?'':'Use HH:MM'); }} inputMode="numeric" required/>{wakeError && <p className="error">{wakeError}</p>}</div>
       </div>
       <label>Sleep quality: <b>{quality}</b></label>
       <input type="range" min={1} max={5} step={1} value={quality} onChange={e=>setQuality(Number(e.target.value))} />
       <label>Notes</label>
       <textarea rows={4} placeholder="Caffeine? Exercise? Woke at night? Dreams?" value={notes} onChange={e=>setNotes(e.target.value)} />
       <div className="rowflex" style={{marginTop:10}}>
-        <span className="chip">⏱ {duration}</span>
+        <span className="chip">Duration {duration}</span>
         <button className="right" type="submit">Save entry</button>
       </div>
     </form>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,24 +1,37 @@
 :root{
   --radius:16px;
   --shadow:0 6px 24px rgba(0,0,0,.12);
-  --pastel-blue:#cfe8ff;
-  --pastel-pink:#ffe1e8;
-  --pastel-green:#e3f7e8;
-  --bg-light:#fdfdff; --surface-light:#f7f7ff; --muted-light:#ecebff; --text-light:#1f2131;
-  --bg-dark:#0f1218; --surface-dark:#131724; --muted-dark:#1a2030; --text-dark:#e9ecff;
+  --accent1-light:#ffb3ec;
+  --accent2-light:#b3e5ff;
+  --accent1-dark:#ff00ea;
+  --accent2-dark:#00e5ff;
 }
 html{ color-scheme:light dark; }
-html[data-theme="light"]{ --bg:var(--bg-light); --surface:var(--surface-light); --muted:var(--muted-light); --text:var(--text-light); }
-html[data-theme="dark"]{ --bg:var(--bg-dark); --surface:var(--surface-dark); --muted:var(--muted-dark); --text:var(--text-dark); }
+html[data-theme="light"]{
+  --bg:linear-gradient(135deg,#ffe6fa,#e6f7ff);
+  --surface:rgba(255,255,255,0.6);
+  --muted:rgba(255,255,255,0.3);
+  --text:#1f2131;
+  --accent1:var(--accent1-light);
+  --accent2:var(--accent2-light);
+}
+html[data-theme="dark"]{
+  --bg:radial-gradient(circle at 50% 0%,#050b2a,#000);
+  --surface:rgba(20,22,40,0.6);
+  --muted:rgba(80,90,140,0.3);
+  --text:#e9ecff;
+  --accent1:var(--accent1-dark);
+  --accent2:var(--accent2-dark);
+}
 
-body{ margin:0; background:var(--bg); color:var(--text); font:16px/1.45 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial; min-height:100dvh; overflow-x:hidden; }
+body{ margin:0; background:var(--bg); background-attachment:fixed; color:var(--text); font:16px/1.45 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial; min-height:100dvh; overflow-x:hidden; }
 .container{ max-width:1000px; margin:0 auto; padding:28px; }
 
 /* Cards / bars */
 .bar{ display:flex; align-items:center; justify-content:space-between; gap:12px; backdrop-filter: blur(8px); background: color-mix(in oklab, var(--surface) 80%, transparent); padding:12px 16px; margin:16px; border-radius:18px; box-shadow:var(--shadow); }
 .brand{ display:flex; align-items:center; gap:12px; font-weight:700; }
-.brand .dot{ width:12px; height:12px; border-radius:99px; background: linear-gradient(135deg,var(--pastel-blue),var(--pastel-pink)); box-shadow:0 0 18px var(--pastel-blue); }
-.card{ background: color-mix(in oklab, var(--surface) 92%, transparent); border:1px solid color-mix(in oklab, var(--muted) 55%, transparent); border-radius:18px; box-shadow: var(--shadow); padding:18px; }
+.brand .dot{ width:12px; height:12px; border-radius:99px; background: linear-gradient(135deg,var(--accent1),var(--accent2)); box-shadow:0 0 18px var(--accent1); }
+.card{ backdrop-filter: blur(10px); background: color-mix(in oklab, var(--surface) 92%, transparent); border:1px solid color-mix(in oklab, var(--muted) 55%, transparent); border-radius:18px; box-shadow: var(--shadow); padding:18px; }
 .grid{ display:grid; grid-template-columns:1.1fr .9fr; gap:20px; }
 @media (max-width: 900px){ .grid{ grid-template-columns:1fr; } }
 
@@ -26,17 +39,16 @@ body{ margin:0; background:var(--bg); color:var(--text); font:16px/1.45 ui-sans-
 label{ display:block; font-weight:600; margin:10px 0 6px; }
 input,textarea,select{ width:100%; border-radius:12px; border:1px solid color-mix(in oklab, var(--muted) 50%, transparent); background: color-mix(in oklab, var(--surface) 90%, transparent); color:var(--text); padding:10px 12px; }
 input[type=range]{ height:30px; }
-button{ appearance:none; border:0; cursor:pointer; background:linear-gradient(135deg,var(--pastel-blue),var(--pastel-pink)); color:#0b0d13; padding:10px 14px; border-radius:12px; font-weight:700; box-shadow:0 6px 18px color-mix(in oklab, var(--pastel-blue) 30%, transparent); transition:transform .22s ease, box-shadow .22s ease, opacity .22s ease; }
+button{ appearance:none; border:0; cursor:pointer; background:linear-gradient(135deg,var(--accent1),var(--accent2)); color:#0b0d13; padding:10px 14px; border-radius:12px; font-weight:700; box-shadow:0 6px 18px color-mix(in oklab, var(--accent2) 30%, transparent); transition:transform .22s ease, box-shadow .22s ease, opacity .22s ease; }
 button:hover{ transform:translateY(-1px); } button:active{ transform:translateY(0); opacity:.9; }
 .ghost{ background: color-mix(in oklab, var(--muted) 35%, transparent); color:var(--text); }
 
 /* Lists */
 .list{ display:grid; gap:12px; }
 .entry{ background: color-mix(in oklab, var(--surface) 95%, transparent); border:1px solid color-mix(in oklab, var(--muted) 50%, transparent); border-radius:14px; padding:12px 14px; }
-.chip{ display:inline-flex; align-items:center; gap:8px; padding:6px 10px; border-radius:999px; background: color-mix(in oklab, var(--pastel-green) 26%, transparent); color:#0b0d13; font-weight:700; }
+.chip{ display:inline-flex; align-items:center; gap:8px; padding:6px 10px; border-radius:999px; background: color-mix(in oklab, var(--accent2) 26%, transparent); color:#0b0d13; font-weight:700; }
 .muted{ color: color-mix(in oklab, var(--text) 70%, transparent); }
 .strong{ font-weight:700; }
-.footer{ text-align:center; margin:30px 0 60px; opacity:.7; font-size:14px; }
 .rowflex{ display:flex; align-items:center; gap:10px; }
 .rowflex.wrap{ flex-wrap:wrap; }
 .rowflex.between{ justify-content:space-between; }
@@ -95,6 +107,19 @@ button:hover{ transform:translateY(-1px); } button:active{ transform:translateY(
 .glow-dark{  mix-blend-mode: screen;   opacity: .65; }
 .glow-light{ mix-blend-mode: multiply; opacity: .75; }
 
+.glow-grid{
+  position:absolute; inset:0;
+  background:
+    repeating-linear-gradient(45deg, rgba(255,0,234,.1) 0 2px, transparent 2px 20px),
+    repeating-linear-gradient(-45deg, rgba(0,229,255,.1) 0 2px, transparent 2px 20px);
+  mix-blend-mode:overlay;
+  animation:gridmove 20s linear infinite;
+}
+@keyframes gridmove{
+  from{ transform:translateY(0); }
+  to{ transform:translateY(40px); }
+}
+
 
 /* Subtle grain overlay for depth */
 body::after{ content:""; position:fixed; inset:0; pointer-events:none; z-index:-1; background-image:url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 160 160"><filter id="n"><feTurbulence type="fractalNoise" baseFrequency="0.75" numOctaves="2" stitchTiles="stitch"/></filter><rect width="100%" height="100%" filter="url(%23n)" opacity=".035"/></svg>'); mix-blend-mode: soft-light; }
@@ -140,24 +165,6 @@ body::after{ content:""; position:fixed; inset:0; pointer-events:none; z-index:-
   border-radius:16px; box-shadow: var(--shadow); padding:16px;
 }
 
-/* Toggle for Icons/Text */
-.actions-style{
-  display:flex; align-items:center; justify-content:flex-end; gap:8px; margin:6px 0 10px;
-}
-.segmented{
-  display:inline-flex; gap:2px; padding:2px;
-  border-radius:999px;
-  background: color-mix(in oklab, var(--muted) 30%, transparent);
-}
-.segmented .seg{
-  border:0; padding:6px 10px; border-radius:999px; cursor:pointer;
-  background: transparent; color: var(--text); font-weight:600; font-size:12px;
-}
-.segmented .seg.on{
-  background: color-mix(in oklab, var(--surface) 85%, transparent);
-  box-shadow: 0 2px 8px rgba(0,0,0,.10);
-}
-
 .textbtn{
   appearance:none; border:0; background: color-mix(in oklab, var(--muted) 28%, transparent);
   padding:6px 10px; border-radius:10px; cursor:pointer; font-weight:700;
@@ -170,3 +177,6 @@ body::after{ content:""; position:fixed; inset:0; pointer-events:none; z-index:-
   position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden;
   clip:rect(0,0,0,0); white-space:nowrap; border:0;
 }
+
+/* Validation */
+.error{ color:#ff6b6b; font-size:12px; margin-top:4px; }


### PR DESCRIPTION
## Summary
- Refresh layout with dreamy gradients, new tagline and dynamic neon grid overlay for dark mode
- Replace emoji action buttons with text and add HH:MM validation for sleep times
- Remove footer and switch to 24-hour duration chips

## Testing
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_689feb1e87ec832a8fd12cb87824e87a