### PR TITLE
Revamp Dream Logs sign‑in and background

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import '../styles/globals.css';
-export const metadata = { title: 'Sleep Journal', description: 'Dreamy futuristic sleep journal with Supabase sync' };
+export const metadata = { title: 'Dream Logs', description: 'Dreamy futuristic sleep journal with Supabase sync' };
 
 const ThemeScript = () => (
   <script

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -54,15 +54,17 @@ export default function Page(){
     setTheme(next);
   };
 
+  const blockWidth = session?.user ? 680 : 600;
+
   return (
     <main>
       <GlowBackground base={palette} avgQuality={avgQuality} theme={theme} />
       {!session?.user && <div className="login-orbs" aria-hidden />}
       <div className="container">
-        <header className="bar" style={{maxWidth:680, margin:'0 auto 24px'}}>
-          <h1 style={{margin:0, fontSize:'1.8rem', flex:1}}>Your Sleep Journal</h1>
+        <header className="bar" style={{maxWidth:blockWidth, margin:'0 auto 24px'}}>
+          <h1 style={{margin:0, fontSize:'1.8rem', flex:1}}>Dream Logs</h1>
           <div className="rowflex">
-            <button className="iconbtn" onClick={toggleTheme} aria-label="Toggle theme">{theme==='dark' ? '☀' : '☾'}</button>
+            <button className="iconbtn theme-toggle" onClick={toggleTheme} aria-label="Toggle theme" style={{color: theme==='dark' ? '#ffd54f' : undefined}}>{theme==='dark' ? '☀' : '☾'}</button>
             {session?.user ? (
               <>
                 <span className="muted" style={{marginLeft:8}}>{session.user.email}</span>
@@ -74,21 +76,19 @@ export default function Page(){
 
         {session?.user ? (
           <>
-            <section className="card" style={{maxWidth:680, margin:'0 auto'}}>
+            <section className="card" style={{maxWidth:blockWidth, margin:'0 auto'}}>
               <h2>Log your sleep</h2>
               <SleepForm onSaved={() => { refreshAvg(); setRefreshKey(k => k + 1); }} />
             </section>
-            <section className="card" style={{maxWidth:680, margin:'24px auto 0'}}>
+            <section className="card" style={{maxWidth:blockWidth, margin:'24px auto 0'}}>
               <h2>Your entries</h2>
               <EntriesList refreshKey={refreshKey} />
             </section>
           </>
         ) : (
-          <section className="card" style={{maxWidth:500, margin:'0 auto'}}>
-            <h2>Welcome</h2>
-            <p className="muted">Sign in with <b>email & password</b> or use a <b>magic link</b>. No servers required.</p>
+          <div style={{maxWidth:blockWidth, margin:'0 auto'}}>
             <AuthPanel />
-          </section>
+          </div>
         )}
 
       </div>

--- a/components/AuthPanel.tsx
+++ b/components/AuthPanel.tsx
@@ -68,8 +68,8 @@ export default function AuthPanel(){
       </div>
 
       {mode==='password' ? (
-        <div style={{display:'flex', flexDirection:'column', gap:20}}>
-          <form onSubmit={signIn}>
+        <div className="auth-grid" style={{marginTop:8}}>
+          <form onSubmit={signIn} className="card auth-block">
             <h3 style={{margin:'4px 0'}}>Sign in</h3>
             <input
               type="email"
@@ -92,7 +92,7 @@ export default function AuthPanel(){
               <button type="button" className="ghost" onClick={forgotPassword}>Forgot?</button>
             </div>
           </form>
-          <form onSubmit={signUp}>
+          <form onSubmit={signUp} className="card auth-block">
             <h3 style={{margin:'4px 0'}}>Create account</h3>
             <input
               type="email"
@@ -122,7 +122,7 @@ export default function AuthPanel(){
           </form>
         </div>
       ) : (
-        <form onSubmit={sendMagicLink} className="rowflex" style={{gap:12, flexWrap:'wrap', marginTop:8}}>
+        <form onSubmit={sendMagicLink} className="card auth-block rowflex" style={{gap:12, flexWrap:'wrap', marginTop:8}}>
           <input
             type="email"
             required

--- a/components/GlowBackground.tsx
+++ b/components/GlowBackground.tsx
@@ -15,8 +15,8 @@ export default function GlowBackground({ theme }: Props){
     let raf = 0;
     let t = 0;
 
-    const speed = 0.006;
-    const spread = 1.0;
+    const speed = 0.012;
+    const spread = 0.8;
 
     const step = () => {
       t += speed;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -35,6 +35,9 @@ body{ margin:0; background:var(--bg); background-attachment:fixed; color:var(--t
 .grid{ display:grid; grid-template-columns:1.1fr .9fr; gap:20px; }
 @media (max-width: 900px){ .grid{ grid-template-columns:1fr; } }
 
+.auth-grid{ display:flex; gap:20px; flex-wrap:wrap; align-items:stretch; }
+.auth-block{ flex:1 1 260px; display:flex; flex-direction:column; gap:12px; }
+
 /* Inputs */
 label{ display:block; font-weight:600; margin:10px 0 6px; }
 input,textarea,select{ width:100%; border-radius:12px; border:1px solid color-mix(in oklab, var(--muted) 50%, transparent); background: color-mix(in oklab, var(--surface) 90%, transparent); color:var(--text); padding:10px 12px; }
@@ -79,18 +82,20 @@ button:hover{ transform:translateY(-1px); } button:active{ transform:translateY(
 .glow.glow-full::before{
   background:
     radial-gradient(40vmax 40vmax at 25% 35%, oklch(88% .10 var(--h,0)) 0%, transparent 70%),
-    radial-gradient(36vmax 36vmax at 70% 60%, oklch(86% .09 calc(var(--h,0) + 60)) 0%, transparent 72%);
+    radial-gradient(36vmax 36vmax at 70% 60%, oklch(86% .09 calc(var(--h,0) + 120)) 0%, transparent 72%),
+    radial-gradient(44vmax 44vmax at 50% 80%, oklch(88% .08 calc(var(--h,0) + 240)) 0%, transparent 74%);
   transform: translate(calc(-6vmax*var(--spread,1)), -2vmax);
-  animation: float1 24s ease-in-out infinite alternate;
+  animation: float1 16s ease-in-out infinite alternate;
 }
 
 /* Secondary lobe */
 .glow.glow-full::after{
   background:
-    radial-gradient(42vmax 42vmax at 30% 70%, oklch(90% .09 calc(var(--h,0) + 140)) 0%, transparent 72%),
-    radial-gradient(38vmax 38vmax at 75% 30%, oklch(90% .08 calc(var(--h,0) + 220)) 0%, transparent 70%);
+    radial-gradient(42vmax 42vmax at 30% 70%, oklch(90% .09 calc(var(--h,0) + 60)) 0%, transparent 72%),
+    radial-gradient(38vmax 38vmax at 75% 30%, oklch(90% .08 calc(var(--h,0) + 180)) 0%, transparent 70%),
+    radial-gradient(46vmax 46vmax at 20% 20%, oklch(92% .08 calc(var(--h,0) + 300)) 0%, transparent 68%);
   transform: translate(calc(6vmax*var(--spread,1)), 2vmax);
-  animation: float2 28s ease-in-out infinite alternate;
+  animation: float2 18s ease-in-out infinite alternate;
 }
 
 /* Slightly quicker orbital motion to match the faster hue drift */
@@ -185,6 +190,7 @@ textarea{ resize:vertical; max-width:100%; }
   padding:6px 8px; border-radius:10px; line-height:1;
   background: color-mix(in oklab, var(--muted) 30%, transparent);
   box-shadow: 0 2px 10px rgba(0,0,0,.08);
+  color:var(--text);
 }
 .iconbtn:hover{ transform: translateY(-1px); }
 .iconbtn.danger{ background: color-mix(in oklab, #ffb3c1 35%, transparent); }


### PR DESCRIPTION
## Summary
- Rename app to "Dream Logs" and sync header width with content
- Split authentication into equal Sign In and Create Account cards
- Brighten theme toggle icon and enrich faster, multi-blob background glow

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0c430b17c832aa24cbdd97c76becd